### PR TITLE
fix: ensure override UUIDs are always resolved

### DIFF
--- a/opnsense/core/unbound/overrides/aliases.go
+++ b/opnsense/core/unbound/overrides/aliases.go
@@ -29,7 +29,22 @@ func (o OverridesAliasesApi) Create(alias *OverridesAlias) (*OverridesAlias, err
 		return nil, fmt.Errorf("error unmarshalling response: %w", err)
 	}
 
-	alias.Alias.Uuid = result.Uuid
+	uuid := result.Uuid
+	if uuid == "" {
+		uuid = extractUUIDFromResponse(request)
+	}
+	if uuid == "" {
+		resolved, resolveErr := findHostAliasUUIDByHostDomain(o.api, alias.Alias.Hostname, alias.Alias.Domain)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("error resolving created alias uuid: %w", resolveErr)
+		}
+		uuid = resolved
+	}
+	if err := requireUUID("host alias", request, uuid); err != nil {
+		return nil, err
+	}
+
+	alias.Alias.Uuid = uuid
 	return alias, nil
 }
 

--- a/opnsense/core/unbound/overrides/api_mock_test.go
+++ b/opnsense/core/unbound/overrides/api_mock_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 type mockApiState struct {
-	hosts   map[string]string
+	hosts   map[string]map[string]string
 	aliases map[string]OverridesAlias
 }
 
 func newMockOpnSenseServer(t *testing.T) *httptest.Server {
 	state := &mockApiState{
-		hosts:   map[string]string{},
+		hosts:   map[string]map[string]string{},
 		aliases: map[string]OverridesAlias{},
 	}
 
@@ -40,18 +40,28 @@ func newMockOpnSenseServer(t *testing.T) *httptest.Server {
 			err := json.NewDecoder(r.Body).Decode(&host)
 			require.NoError(t, err)
 			hostname, _ := host.Host["hostname"].(string)
-			state.hosts["host-1"] = hostname
+			domain, _ := host.Host["domain"].(string)
+			state.hosts["host-1"] = map[string]string{"hostname": hostname, "domain": domain}
+			if strings.Contains(hostname, "no-uuid") {
+				_, _ = w.Write([]byte(`{"result":"saved"}`))
+				return
+			}
 			_, _ = w.Write([]byte(`{"result":"saved","uuid":"host-1"}`))
 			return
 
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/unbound/settings/get_host_override/"):
 			uuid := strings.TrimPrefix(r.URL.Path, "/api/unbound/settings/get_host_override/")
-			hostname, found := state.hosts[uuid]
+			hostData, found := state.hosts[uuid]
 			if !found {
 				_, _ = w.Write([]byte(`[]`))
 				return
 			}
+			hostname := hostData["hostname"]
+			domain := hostData["domain"]
 			payload := fmt.Sprintf(`{"host":{"enabled":"1","hostname":"%s","domain":"example.local","rr":{"A":{"value":"A","selected":1}},"description":"unit-test","server":"10.0.0.10"}}`, hostname)
+			if domain != "" {
+				payload = fmt.Sprintf(`{"host":{"enabled":"1","hostname":"%s","domain":"%s","rr":{"A":{"value":"A","selected":1}},"description":"unit-test","server":"10.0.0.10"}}`, hostname, domain)
+			}
 			_, _ = w.Write([]byte(payload))
 			return
 
@@ -63,8 +73,23 @@ func newMockOpnSenseServer(t *testing.T) *httptest.Server {
 			err := json.NewDecoder(r.Body).Decode(&host)
 			require.NoError(t, err)
 			hostname, _ := host.Host["hostname"].(string)
-			state.hosts[uuid] = hostname
+			domain, _ := host.Host["domain"].(string)
+			state.hosts[uuid] = map[string]string{"hostname": hostname, "domain": domain}
 			_, _ = w.Write([]byte(`{"result":"saved"}`))
+			return
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/unbound/settings/search_host_override":
+			rows := []map[string]any{}
+			for uuid, hostData := range state.hosts {
+				rows = append(rows, map[string]any{
+					"uuid":     uuid,
+					"hostname": hostData["hostname"],
+					"domain":   hostData["domain"],
+				})
+			}
+			payload, err := json.Marshal(map[string]any{"rows": rows})
+			require.NoError(t, err)
+			_, _ = w.Write(payload)
 			return
 
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/unbound/settings/del_host_override/"):
@@ -78,6 +103,10 @@ func newMockOpnSenseServer(t *testing.T) *httptest.Server {
 			err := json.NewDecoder(r.Body).Decode(&alias)
 			require.NoError(t, err)
 			state.aliases["alias-1"] = alias
+			if strings.Contains(alias.Alias.Hostname, "no-uuid") {
+				_, _ = w.Write([]byte(`{"result":"saved"}`))
+				return
+			}
 			_, _ = w.Write([]byte(`{"result":"saved","uuid":"alias-1"}`))
 			return
 
@@ -106,6 +135,20 @@ func newMockOpnSenseServer(t *testing.T) *httptest.Server {
 			uuid := strings.TrimPrefix(r.URL.Path, "/api/unbound/settings/del_host_alias/")
 			delete(state.aliases, uuid)
 			_, _ = w.Write([]byte(`{"result":"deleted"}`))
+			return
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/unbound/settings/search_host_alias":
+			rows := []map[string]any{}
+			for uuid, alias := range state.aliases {
+				rows = append(rows, map[string]any{
+					"uuid":     uuid,
+					"hostname": alias.Alias.Hostname,
+					"domain":   alias.Alias.Domain,
+				})
+			}
+			payload, err := json.Marshal(map[string]any{"rows": rows})
+			require.NoError(t, err)
+			_, _ = w.Write(payload)
 			return
 		}
 
@@ -189,4 +232,47 @@ func TestAliasesOverrideApi_CRUD_WithMockedOpnSenseEndpoints(t *testing.T) {
 	deleted, err := aliases.Read("alias-1")
 	require.NoError(t, err)
 	assert.Nil(t, deleted)
+}
+
+func TestHostsOverrideApi_Create_ResolvesUUIDViaSearchWhenMissingInResponse(t *testing.T) {
+	server := newMockOpnSenseServer(t)
+	defer server.Close()
+
+	api := opnsense.NewOpnSenseClient(server.URL, "test-key", "test-secret")
+	api.SetInsecureSkipVerify(true)
+	hosts := GetHostsOverrideApi(api)
+
+	host := &OverridesHost{Host: OverridesHostDetails{
+		Enabled:     true,
+		Hostname:    "no-uuid-host",
+		Domain:      "example.local",
+		Rr:          "A",
+		Description: "unit-test",
+		Server:      "10.0.0.10",
+	}}
+
+	created, err := hosts.Create(host)
+	require.NoError(t, err)
+	assert.Equal(t, "host-1", created.Host.Uuid)
+}
+
+func TestAliasesOverrideApi_Create_ResolvesUUIDViaSearchWhenMissingInResponse(t *testing.T) {
+	server := newMockOpnSenseServer(t)
+	defer server.Close()
+
+	api := opnsense.NewOpnSenseClient(server.URL, "test-key", "test-secret")
+	api.SetInsecureSkipVerify(true)
+	aliases := GetAliasesOverrideApi(api)
+
+	alias := &OverridesAlias{Alias: OverridesAliasDetails{
+		Enabled:     true,
+		Host:        "host-1",
+		Hostname:    "no-uuid-alias",
+		Domain:      "example.local",
+		Description: "unit-test-alias",
+	}}
+
+	created, err := aliases.Create(alias)
+	require.NoError(t, err)
+	assert.Equal(t, "alias-1", created.Alias.Uuid)
 }

--- a/opnsense/core/unbound/overrides/hosts.go
+++ b/opnsense/core/unbound/overrides/hosts.go
@@ -34,7 +34,22 @@ func (o OverridesHostsApi) Create(host *OverridesHost) (*OverridesHost, error) {
 		return nil, fmt.Errorf("error unmarshalling response: %w", err)
 	}
 
-	host.Host.Uuid = result.Uuid
+	uuid := result.Uuid
+	if uuid == "" {
+		uuid = extractUUIDFromResponse(request)
+	}
+	if uuid == "" {
+		resolved, resolveErr := findHostOverrideUUIDByHostDomain(o.api, host.Host.Hostname, host.Host.Domain)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("error resolving created host uuid: %w", resolveErr)
+		}
+		uuid = resolved
+	}
+	if err := requireUUID("host override", request, uuid); err != nil {
+		return nil, err
+	}
+
+	host.Host.Uuid = uuid
 	return host, nil
 }
 

--- a/opnsense/core/unbound/overrides/uuid_resolver.go
+++ b/opnsense/core/unbound/overrides/uuid_resolver.go
@@ -1,0 +1,149 @@
+package overrides
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/oss4u/go-opnsense/opnsense"
+)
+
+func extractUUIDFromResponse(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(findUUIDInAny(decoded))
+}
+
+func findUUIDInAny(v any) string {
+	switch typed := v.(type) {
+	case map[string]any:
+		if value, ok := typed["uuid"].(string); ok && strings.TrimSpace(value) != "" {
+			return value
+		}
+
+		if result := typed["result"]; result != nil {
+			if uuid := findUUIDInAny(result); uuid != "" {
+				return uuid
+			}
+		}
+
+		for _, child := range typed {
+			if uuid := findUUIDInAny(child); uuid != "" {
+				return uuid
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if uuid := findUUIDInAny(child); uuid != "" {
+				return uuid
+			}
+		}
+	}
+
+	return ""
+}
+
+func findHostOverrideUUIDByHostDomain(api *opnsense.OpnSenseApi, hostname, domain string) (string, error) {
+	searchPayload := map[string]any{
+		"current":  1,
+		"rowCount": 500,
+	}
+
+	payloadRaw, err := json.Marshal(searchPayload)
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := api.ModifyingRequest("unbound", "settings", "search_host_override", string(payloadRaw), []string{})
+	if err != nil {
+		return "", err
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return "", err
+	}
+
+	rows, ok := decoded["rows"].([]any)
+	if !ok {
+		return "", nil
+	}
+
+	for _, row := range rows {
+		rowMap, ok := row.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		candidateHost, _ := rowMap["hostname"].(string)
+		candidateDomain, _ := rowMap["domain"].(string)
+		uuid, _ := rowMap["uuid"].(string)
+
+		if strings.EqualFold(strings.TrimSpace(candidateHost), strings.TrimSpace(hostname)) &&
+			strings.EqualFold(strings.TrimSpace(candidateDomain), strings.TrimSpace(domain)) {
+			return strings.TrimSpace(uuid), nil
+		}
+	}
+
+	return "", nil
+}
+
+func findHostAliasUUIDByHostDomain(api *opnsense.OpnSenseApi, hostname, domain string) (string, error) {
+	searchPayload := map[string]any{
+		"current":  1,
+		"rowCount": 500,
+	}
+
+	payloadRaw, err := json.Marshal(searchPayload)
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := api.ModifyingRequest("unbound", "settings", "search_host_alias", string(payloadRaw), []string{})
+	if err != nil {
+		return "", err
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return "", err
+	}
+
+	rows, ok := decoded["rows"].([]any)
+	if !ok {
+		return "", nil
+	}
+
+	for _, row := range rows {
+		rowMap, ok := row.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		candidateHost, _ := rowMap["hostname"].(string)
+		candidateDomain, _ := rowMap["domain"].(string)
+		uuid, _ := rowMap["uuid"].(string)
+
+		if strings.EqualFold(strings.TrimSpace(candidateHost), strings.TrimSpace(hostname)) &&
+			strings.EqualFold(strings.TrimSpace(candidateDomain), strings.TrimSpace(domain)) {
+			return strings.TrimSpace(uuid), nil
+		}
+	}
+
+	return "", nil
+}
+
+func requireUUID(entity, rawResponse, parsedUUID string) error {
+	if strings.TrimSpace(parsedUUID) != "" {
+		return nil
+	}
+
+	return fmt.Errorf("%s create response did not contain a uuid: %s", entity, strings.TrimSpace(rawResponse))
+}


### PR DESCRIPTION
## Summary\n- make host/alias override create robust when OPNsense omits  in immediate response\n- add UUID extraction across response shapes and search fallback by hostname/domain\n- add tests for missing-uuid response path to guarantee ID propagation\n\n## Validation\n- go test ./opnsense/core/unbound/overrides/...\n- go test ./...